### PR TITLE
feat: solve CLIPVisionModelOutput object has no attribute penultimate…

### DIFF
--- a/IPAdapterPlus.py
+++ b/IPAdapterPlus.py
@@ -128,6 +128,9 @@ def max_(tensor_list):
     mx = x.max(axis=0)[0]
     return torch.clamp(mx, max=1)
 
+def get_hidden_states(embed):
+    return embed.penultimate_hidden_states if hasattr(embed, 'penultimate_hidden_states') else embed.last_hidden_state
+
 # From https://github.com/Jamy-L/Pytorch-Contrast-Adaptive-Sharpening/
 def contrast_adaptive_sharpening(image, amount):
     img = F.pad(image, pad=(1, 1, 1, 1)).cpu()
@@ -323,9 +326,9 @@ class IPAdapterApply:
             neg_image = image_add_noise(image, noise) if noise > 0 else None
             
             if self.is_plus:
-                clip_embed = clip_embed.penultimate_hidden_states
+                clip_embed = get_hidden_states(clip_embed)
                 if noise > 0:
-                    clip_embed_zeroed = clip_vision.encode_image(neg_image).penultimate_hidden_states
+                    clip_embed_zeroed = get_hidden_states(clip_vision.encode_image(neg_image))
                 else:
                     clip_embed_zeroed = zeroed_hidden_states(clip_vision, image.shape[0])
             else:
@@ -467,9 +470,9 @@ class IPAdapterEncoder:
         neg_image = image_add_noise(image, noise) if noise > 0 else None
         
         if plus:
-            clip_embed = clip_embed.penultimate_hidden_states
+            clip_embed = get_hidden_states(clip_embed)
             if noise > 0:
-                clip_embed_zeroed = clip_vision.encode_image(neg_image).penultimate_hidden_states
+                clip_embed_zeroed = get_hidden_states(clip_vision.encode_image(neg_image))
             else:
                 clip_embed_zeroed = zeroed_hidden_states(clip_vision, image.shape[0])
         else:


### PR DESCRIPTION
when `penultimate_hidden_states` do not exist, use `last_hidden_state`, to solve this issue:

![image](https://github.com/cubiq/ComfyUI_IPAdapter_plus/assets/29772821/dd971ad1-7272-42e1-9a26-d5d8fa3412a2)

```
Error occurred when executing IPAdapterApply:

'CLIPVisionModelOutput' object has no attribute 'penultimate_hidden_states'

File "/data/dev/comfyui-latest/execution.py", line 152, in recursive_execute
output_data, output_ui = get_output_data(obj, input_data_all)
File "/data/dev/comfyui-latest/execution.py", line 82, in get_output_data
return_values = map_node_over_list(obj, input_data_all, obj.FUNCTION, allow_interrupt=True)
File "/data/dev/comfyui-latest/execution.py", line 75, in map_node_over_list
results.append(getattr(obj, func)(**slice_dict(input_data_all, i)))
```

When using the plus model such as `ip-adapter-plus-face_sd15`, it appears stable.
