### PR TITLE
Added ability to pad images to PrepImageForClipVision Node

### DIFF
--- a/IPAdapterPlus.py
+++ b/IPAdapterPlus.py
@@ -476,7 +476,7 @@ class PrepImageForClipVision:
 
     CATEGORY = "ipadapter"
 
-    def prep_image(self, image, padding, interpolation="LANCZOS", crop_position="center", sharpening=0.0, output_size=244):
+    def prep_image(self, image, padding, interpolation="LANCZOS", crop_position="center", sharpening=0.0):
         #add padding to image
         if padding:
             image = pad_to_square(image)     
@@ -507,7 +507,7 @@ class PrepImageForClipVision:
         imgs = []
         for i in range(output.shape[0]):
             img = TT.ToPILImage()(output[i])
-            img = img.resize((output_size,output_size), resample=Image.Resampling[interpolation])
+            img = img.resize((244,244), resample=Image.Resampling[interpolation])
             imgs.append(TT.ToTensor()(img))
         output = torch.stack(imgs, dim=0)
        

--- a/IPAdapterPlus.py
+++ b/IPAdapterPlus.py
@@ -507,7 +507,7 @@ class PrepImageForClipVision:
         imgs = []
         for i in range(output.shape[0]):
             img = TT.ToPILImage()(output[i])
-            img = img.resize((244,244), resample=Image.Resampling[interpolation])
+            img = img.resize((224,224), resample=Image.Resampling[interpolation])
             imgs.append(TT.ToTensor()(img))
         output = torch.stack(imgs, dim=0)
        


### PR DESCRIPTION
Code taken from a node in @laksjdjf implementation. Adds a boolean switch to the "Prepare Image For Clip Vision" node to create padding for the input image.

This adds black bars to the image if it isn't square so the entire contents of the input image are kept and the black bars keep the image at the correct size. I have found this to be helpful with getting the contents of all of a wide image into IPAdapter, however it does have the caveat that at high IPAdapter weights, it can pull the black bars into the image.