### PR TITLE
With a single mask, the masking code introduced in ebd946f breaks the interpolate() call

### DIFF
--- a/IPAdapterPlus.py
+++ b/IPAdapterPlus.py
@@ -313,7 +313,8 @@ class CrossAttentionPatch:
                             mask_downsample = mask_downsample[ad_params["sub_idxs"]]
                     # otherwise, perform usual mask interpolation
                     else:
-                        mask_downsample = F.interpolate(mask.unsqueeze(1), size=(mask_h, mask_w), mode="bicubic").squeeze(1)
+                        mask_downsample = F.interpolate(mask.unsqueeze(0).unsqueeze(0), size=(mask_h, mask_w), mode="bicubic").squeeze(0)
+
 
                     # if we don't have enough masks repeat the last one until we reach the right size
                     if mask_downsample.shape[0] < batch_prompt:


### PR DESCRIPTION
The F.interpolate function expects the input to be in the format of (N, C, H, W) for 2D data (where N is batch size, C is channel count, H is height, and W is width). To fix the error, the shape of mask must have a batch size of 1 and and channel dimension of 1. We can achieve this by unsqueezing twice as the pre-ebd946f code did, which will properly format the tensor: mask.unsqueeze(0).unsqueeze(0). This changes the shape to [1, 1, H, W] (N, C, H, W format).