### PR TITLE
Fix: Prevent NoneType error in IPAdapterPlus.py

### DIFF
--- a/IPAdapterPlus.py
+++ b/IPAdapterPlus.py
@@ -454,8 +454,9 @@ class CrossAttentionPatch:
     def __call__(self, n, context_attn2, value_attn2, extra_options):
         org_dtype = n.dtype
         cond_or_uncond = extra_options["cond_or_uncond"]
-        sigma = extra_options["sigmas"][0] if 'sigmas' in extra_options else None
-        sigma = sigma.item() if sigma is not None else 999999999.9
+        # Split the operation into two parts for a temporary fix of issue-109 (comfyui won't start generating)
+        temp_sigma = extra_options["sigmas"] if 'sigmas' in extra_options else None
+        sigma = temp_sigma[0].item() if temp_sigma else 999999999.9
 
         # extra options for AnimateDiff
         ad_params = extra_options['ad_params'] if "ad_params" in extra_options else None


### PR DESCRIPTION
Problem: The original code attempted to access the first element of extra_options["sigmas"] and convert it to a Python number in a single line. However, if extra_options["sigmas"] did not exist or was None, this would raise an error because you can’t access an element of None.

Solution: The solution was to split this operation into two parts. First, we check if extra_options["sigmas"] exists and is not None. If it is, we set sigma to 999999999.9. If extra_options["sigmas"] does exist, we then access the first element and convert it to a Python number. This prevents any attempts to access an element of None, which would raise an error.

The solution has been checked for it's working on a Windows-AMD Machine :- 
CPU :- AMD 5800x
GPU :- AMD 6600xt
OS :- Windows
RAM :- 16GB
VRAM :- 8GB
ComfyUI :- using --directml

Solution Thanks to [JerekDerp](https://github.com/JarekDerp)



