### PR TITLE
For those who confused by the "Model Not Found" error.

### DIFF
--- a/IPAdapterPlus.py
+++ b/IPAdapterPlus.py
@@ -435,7 +435,7 @@ class IPAdapterUnifiedLoader:
         # 1. Load the clipvision model
         clipvision_file, search_pattern = get_clipvision_file(preset)
         if clipvision_file is None:
-            raise Exception(f"ClipVision model not found.\n\nSearching for {search_pattern}")
+            raise Exception(f"ClipVision model not found.\n\nSearching for {search_pattern}\n\nTry to download it from <a href='https://github.com/cubiq/ComfyUI_IPAdapter_plus#installation' target='_blank' style='color:white'>HERE</a>")
 
         if clipvision_file != self.clipvision['file']:
             if clipvision_file != pipeline['clipvision']['file']:
@@ -449,7 +449,7 @@ class IPAdapterUnifiedLoader:
         is_sdxl = isinstance(model.model, (comfy.model_base.SDXL, comfy.model_base.SDXLRefiner, comfy.model_base.SDXL_instructpix2pix))
         ipadapter_file, is_insightface, lora_pattern, search_pattern = get_ipadapter_file(preset, is_sdxl)
         if ipadapter_file is None:
-            raise Exception(f"IPAdapter model not found.\n\nSearching for {search_pattern}")
+            raise Exception(f"IPAdapter model not found.\n\nSearching for {search_pattern}\n\nTry to download it from <a href='https://github.com/cubiq/ComfyUI_IPAdapter_plus#installation' target='_blank' style='color:white'>HERE</a>")
 
         if ipadapter_file != self.ipadapter['file']:
             if pipeline['ipadapter']['file'] != ipadapter_file:

--- a/IPAdapterPlus.py
+++ b/IPAdapterPlus.py
@@ -433,9 +433,9 @@ class IPAdapterUnifiedLoader:
             pipeline = ipadapter
 
         # 1. Load the clipvision model
-        clipvision_file = get_clipvision_file(preset)
+        clipvision_file, search_pattern = get_clipvision_file(preset)
         if clipvision_file is None:
-            raise Exception("ClipVision model not found.")
+            raise Exception(f"ClipVision model not found.\n\nSearching for {search_pattern}")
 
         if clipvision_file != self.clipvision['file']:
             if clipvision_file != pipeline['clipvision']['file']:
@@ -447,9 +447,9 @@ class IPAdapterUnifiedLoader:
 
         # 2. Load the ipadapter model
         is_sdxl = isinstance(model.model, (comfy.model_base.SDXL, comfy.model_base.SDXLRefiner, comfy.model_base.SDXL_instructpix2pix))
-        ipadapter_file, is_insightface, lora_pattern = get_ipadapter_file(preset, is_sdxl)
+        ipadapter_file, is_insightface, lora_pattern, search_pattern = get_ipadapter_file(preset, is_sdxl)
         if ipadapter_file is None:
-            raise Exception("IPAdapter model not found.")
+            raise Exception(f"IPAdapter model not found.\n\nSearching for {search_pattern}")
 
         if ipadapter_file != self.ipadapter['file']:
             if pipeline['ipadapter']['file'] != ipadapter_file:

--- a/utils.py
+++ b/utils.py
@@ -22,7 +22,7 @@ def get_clipvision_file(preset):
 
     clipvision_file = folder_paths.get_full_path("clip_vision", clipvision_file[0]) if clipvision_file else None
 
-    return clipvision_file
+    return clipvision_file, pattern
 
 def get_ipadapter_file(preset, is_sdxl):
     preset = preset.lower()
@@ -110,7 +110,7 @@ def get_ipadapter_file(preset, is_sdxl):
     ipadapter_file = [e for e in ipadapter_list if re.search(pattern, e, re.IGNORECASE)]
     ipadapter_file = folder_paths.get_full_path("ipadapter", ipadapter_file[0]) if ipadapter_file else None
 
-    return ipadapter_file, is_insightface, lora_pattern
+    return ipadapter_file, is_insightface, lora_pattern, pattern
 
 def get_lora_file(pattern):
     lora_list = folder_paths.get_filename_list("loras")


### PR DESCRIPTION
When I install this node to a new machine, many times I forgot to download the models needed. So there'll be the "Model Not Found" error.

Sometimes, I just to demonstrate this node, so I don't want to download all models listed. For example, I might just want to use "LIGHT -SD1.5 only". But the error message I got just tell me "ClipVision model not found". So I was thinking, it'll be great to at least hint me which model is missing, and I can quickly go to the website and download it.

I add this information to the error message, so it'll look like this:

![image](https://github.com/cubiq/ComfyUI_IPAdapter_plus/assets/14249458/cf34f735-dfd5-4fd0-a910-9cb861f1fa00)

I noticed that there are many issues, opened or closed, related to this error message. So, please consider my modification. Thanks.