### PR TITLE
Insightface extra paths

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -154,7 +154,7 @@ def insightface_loader(provider):
     if not folders_insightface:
         path = os.path.join(folder_paths.models_dir, "insightface")
     elif len(folders_insightface)>1:
-        logging.info(f"several insightface folders exist in extra_model_paths.yaml file. Using {folders_insightface[0]}")
+        logging.info(f"[IP ADAPTER PLUS] Several insightface folders exist in extra_model_paths.yaml file. Using {folders_insightface[0]}")
         path=folders_insightface[0]
     else:
         path=folders_insightface[0]

--- a/utils.py
+++ b/utils.py
@@ -9,6 +9,7 @@ try:
     import torchvision.transforms.v2 as T
 except ImportError:
     import torchvision.transforms as T
+import logging
 
 def get_clipvision_file(preset):
     preset = preset.lower()
@@ -149,7 +150,14 @@ def insightface_loader(provider):
     except ImportError as e:
         raise Exception(e)
 
-    path = os.path.join(folder_paths.models_dir, "insightface")
+    folders_insightface=folder_paths.get_folder_paths("insightface")
+    if not folders_insightface:
+        path = os.path.join(folder_paths.models_dir, "insightface")
+    elif len(folders_insightface)>1:
+        logging.info(f"several insightface folders exist in extra_model_paths.yaml file. Using {folders_insightface[0]}")
+        path=folders_insightface[0]
+    else:
+        path=folders_insightface[0]
     model = FaceAnalysis(name="buffalo_l", root=path, providers=[provider + 'ExecutionProvider',])
     model.prepare(ctx_id=0, det_size=(640, 640))
     return model

--- a/utils.py
+++ b/utils.py
@@ -150,14 +150,15 @@ def insightface_loader(provider):
     except ImportError as e:
         raise Exception(e)
 
-    folders_insightface=folder_paths.get_folder_paths("insightface")
-    if not folders_insightface:
+    if not folder_paths.folder_names_and_paths.get("insightface"):
         path = os.path.join(folder_paths.models_dir, "insightface")
-    elif len(folders_insightface)>1:
-        logging.info(f"[IP ADAPTER PLUS] Several insightface folders exist in extra_model_paths.yaml file. Using {folders_insightface[0]}")
-        path=folders_insightface[0]
     else:
-        path=folders_insightface[0]
+        folders_insightface=folder_paths.get_folder_paths("insightface")   
+        if len(folders_insightface)>1:
+            logging.info(f"[IP ADAPTER PLUS] Several insightface folders exist in extra_model_paths.yaml file. Using {folders_insightface[0]}")
+            path=folders_insightface[0]
+        else:
+            path=folders_insightface[0]
     model = FaceAnalysis(name="buffalo_l", root=path, providers=[provider + 'ExecutionProvider',])
     model.prepare(ctx_id=0, det_size=(640, 640))
     return model


### PR DESCRIPTION
In response to issue  #367 

I modified the `insightface_loader` function to have this behavior:

* check if an entry exists for an "insightface" folder inside `extra_model_paths.yaml` file
* if no entry (no key "insightface"), previous behavior (use insightface folder in Comfy/models)
* if multiple entries exist, select the first one as path with a logging.info message to warn the user
* if only one entry, use this one

Some remarks:
* the model is automatically downloaded by insightface package. So if you have already used `Comfy/models/insightface`
 before adding an entry in the yaml file, it will download it in the new place (under yaml_path/models/buffalo_l)
So, you will have a duplication of the model and have to delete the old one manually.
* the code still have "buffalo_l" hard coded in `FaceAnalysis` class. So I think it doesn't adress
@zulfadzlie  remark about "antelopev2" and "buffalo_l" usage. If we want to be able to use an other insightface model
, it should be made in an other PR I think.