### PR TITLE
Skip images where no faces are detected, instead of directly raising an Exception.

### DIFF
--- a/IPAdapterPlus.py
+++ b/IPAdapterPlus.py
@@ -247,7 +247,9 @@ def ipadapter_execute(model,
                         print(f"\033[33mINFO: InsightFace detection resolution lowered to {size}.\033[0m")
                     break
             else:
-                raise Exception('InsightFace: No face detected.')
+                print(f"\033[31mWARN: No face detected in the image[{i}].\033[0m")
+        if len(image) == 0:
+            raise Exception('InsightFace: No face detected any of the images.')
         face_cond_embeds = torch.stack(face_cond_embeds).to(device, dtype=dtype)
         image = torch.stack(image)
         del image_iface, face


### PR DESCRIPTION
When I want to input multiple reference photos for FaceID, if one of the photos fails to detect a face, it will raise an exception with the message ('InsightFace: No face detected'). 

For instance, in the example below, only the photo in the bottom right corner fails to detect a face; the others work fine. 
![screenshot-20240507-193433](https://github.com/cubiq/ComfyUI_IPAdapter_plus/assets/6883957/73e8f2a3-8ce9-4f85-9d90-1d66da4d409b)

Therefore, I am wondering if it might be possible to skip the inputs where faces are not detected and just keep those where faces are detected. Would that be okay?