### PR TITLE
Fix for issue #611 IPAdapter model not found.

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -35,80 +35,80 @@ def get_ipadapter_file(preset, is_sdxl):
     if preset.startswith("light"):
         if is_sdxl:
             raise Exception("light model is not supported for SDXL")
-        pattern = r'sd15.light.v11\.(safetensors|bin)$'
+        pattern = 'sd15.light.v11\.(safetensors|bin)$'
         # if v11 is not found, try with the old version
         if not [e for e in ipadapter_list if re.search(pattern, e, re.IGNORECASE)]:
-            pattern = r'sd15.light\.(safetensors|bin)$'
+            pattern = 'sd15.light\.(safetensors|bin)$'
     elif preset.startswith("standard"):
         if is_sdxl:
-            pattern = r'ip.adapter.sdxl.vit.h\.(safetensors|bin)$'
+            pattern = 'ip.adapter.sdxl.vit.h\.(safetensors|bin)$'
         else:
-            pattern = r'ip.adapter.sd15\.(safetensors|bin)$'
+            pattern = 'ip.adapter.sd15\.(safetensors|bin)$'
     elif preset.startswith("vit-g"):
         if is_sdxl:
-            pattern = r'ip.adapter.sdxl\.(safetensors|bin)$'
+            pattern = 'ip.adapter.sdxl\.(safetensors|bin)$'
         else:
-            pattern = r'sd15.vit.g\.(safetensors|bin)$'
+            pattern = 'sd15.vit.g\.(safetensors|bin)$'
     elif preset.startswith("plus ("):
         if is_sdxl:
-            pattern = r'plus.sdxl.vit.h\.(safetensors|bin)$'
+            pattern = 'plus.sdxl.vit.h\.(safetensors|bin)$'
         else:
-            pattern = r'ip.adapter.plus.sd15\.(safetensors|bin)$'
+            pattern = 'ip.adapter.plus.sd15\.(safetensors|bin)$'
     elif preset.startswith("plus face"):
         if is_sdxl:
-            pattern = r'plus.face.sdxl.vit.h\.(safetensors|bin)$'
+            pattern = 'plus.face.sdxl.vit.h\.(safetensors|bin)$'
         else:
-            pattern = r'plus.face.sd15\.(safetensors|bin)$'
+            pattern = 'plus.face.sd15\.(safetensors|bin)$'
     elif preset.startswith("full"):
         if is_sdxl:
             raise Exception("full face model is not supported for SDXL")
-        pattern = r'full.face.sd15\.(safetensors|bin)$'
+        pattern = 'full.face.sd15\.(safetensors|bin)$'
     elif preset.startswith("faceid portrait ("):
         if is_sdxl:
-            pattern = r'portrait.sdxl\.(safetensors|bin)$'
+            pattern = 'portrait.sdxl\.(safetensors|bin)$'
         else:
-            pattern = r'portrait.v11.sd15\.(safetensors|bin)$'
+            pattern = 'portrait.v11.sd15\.(safetensors|bin)$'
             # if v11 is not found, try with the old version
             if not [e for e in ipadapter_list if re.search(pattern, e, re.IGNORECASE)]:
-                pattern = r'portrait.sd15\.(safetensors|bin)$'
+                pattern = 'portrait.sd15\.(safetensors|bin)$'
         is_insightface = True
     elif preset.startswith("faceid portrait unnorm"):
         if is_sdxl:
-            pattern = r'portrait.sdxl.unnorm\.(safetensors|bin)$'
+            pattern = 'portrait.sdxl.unnorm\.(safetensors|bin)$'
         else:
             raise Exception("portrait unnorm model is not supported for SD1.5")
         is_insightface = True
     elif preset == "faceid":
         if is_sdxl:
-            pattern = r'faceid.sdxl\.(safetensors|bin)$'
-            lora_pattern = r'faceid.sdxl.lora\.safetensors$'
+            pattern = 'faceid.sdxl\.(safetensors|bin)$'
+            lora_pattern = 'faceid.sdxl.lora\.safetensors$'
         else:
-            pattern = r'faceid.sd15\.(safetensors|bin)$'
-            lora_pattern = r'faceid.sd15.lora\.safetensors$'
+            pattern = 'faceid.sd15\.(safetensors|bin)$'
+            lora_pattern = 'faceid.sd15.lora\.safetensors$'
         is_insightface = True
     elif preset.startswith("faceid plus -"):
         if is_sdxl:
             raise Exception("faceid plus model is not supported for SDXL")
-        pattern = r'faceid.plus.sd15\.(safetensors|bin)$'
-        lora_pattern = r'faceid.plus.sd15.lora\.safetensors$'
+        pattern = 'faceid.plus.sd15\.(safetensors|bin)$'
+        lora_pattern = 'faceid.plus.sd15.lora\.safetensors$'
         is_insightface = True
     elif preset.startswith("faceid plus v2"):
         if is_sdxl:
-            pattern = r'faceid.plusv2.sdxl\.(safetensors|bin)$'
-            lora_pattern = r'faceid.plusv2.sdxl.lora\.safetensors$'
+            pattern = 'faceid.plusv2.sdxl\.(safetensors|bin)$'
+            lora_pattern = 'faceid.plusv2.sdxl.lora\.safetensors$'
         else:
-            pattern = r'faceid.plusv2.sd15\.(safetensors|bin)$'
-            lora_pattern = r'faceid.plusv2.sd15.lora\.safetensors$'
+            pattern = 'faceid.plusv2.sd15\.(safetensors|bin)$'
+            lora_pattern = 'faceid.plusv2.sd15.lora\.safetensors$'
         is_insightface = True
     # Community's models
     elif preset.startswith("composition"):
         if is_sdxl:
-            pattern = r'plus.composition.sdxl\.safetensors$'
+            pattern = 'plus.composition.sdxl\.safetensors$'
         else:
-            pattern = r'plus.composition.sd15\.safetensors$'
+            pattern = 'plus.composition.sd15\.safetensors$'
     elif preset.startswith("kolors"):
         if is_sdxl:
-            pattern = r'(ip_adapter_plus_general|kolors.ip.adapter.plus)\.(safetensors|bin)$'
+            pattern = '(ip_adapter_plus_general|kolors.ip.adapter.plus)\.(safetensors|bin)$'
         else:
             raise Exception("Only supported for Kolors model")
     else:


### PR DESCRIPTION
In the project README.md the files to download are named with dashes and not dots. However the util script is looking for dots. A number of people have had the problem that the models can't be loaded and it's not at all obvious why. 
This fix should accommodate both formats of model name.

I did a quick test on my local instal and it seems to work.
