### PR TITLE
Fix for issue with pipeline in load_models

### DIFF
--- a/IPAdapterPlus.py
+++ b/IPAdapterPlus.py
@@ -570,6 +570,15 @@ class IPAdapterUnifiedLoader:
         if ipadapter is not None:
             pipeline = ipadapter
 
+        if 'insightface' not in pipeline:
+            pipeline['insightface'] = { 'provider': None, 'model': None }
+
+        if 'ipadapter' not in pipeline:
+            pipeline['ipadapter'] = { 'file': None, 'model': None }
+
+        if 'clipvision' not in pipeline:
+            pipeline['clipvision'] = { 'file': None, 'model': None }
+
         # 1. Load the clipvision model
         clipvision_file = get_clipvision_file(preset)
         if clipvision_file is None:


### PR DESCRIPTION
This is a fix for issues where the `ipadapter` parameter is supplied in the `load_models` method but isn't decorated with keys for 'clipvision' or 'ipadapter'. This leads to a runtime error in ComfyUI.